### PR TITLE
Inconsistent behavior in toList methos

### DIFF
--- a/lib/cull.js
+++ b/lib/cull.js
@@ -23,7 +23,7 @@ var cull = (function (global) {
     /** Returns a version of `value` that is an actual Array. */
     function toList(value) {
         if (toString.call(value) === "[object Array]") { return value; }
-        if (isList(value)) { return slice.call(value); }
+        if (toString.call(value) === "[object Arguments]") { return slice.call(value); }
         if (typeof value === "undefined" || value === null) { return []; }
         return slice.call(arguments);
     }

--- a/test/cull-test.js
+++ b/test/cull-test.js
@@ -115,6 +115,13 @@ function square(n) { return n * n; }
             "returns arguments as true array": function () {
                 var args = function () { return arguments; };
                 assert.isArray(cull.toList(args(1, 2, 3)));
+            },
+
+            "returns an array with only one element for an object with length": function () {
+                var obj = { length: 3};
+                var arr = cull.toList(obj);
+                assert.equals(arr[0], obj);
+                assert.equals(arr.length, 1);
             }
         },
 


### PR DESCRIPTION
when doing cull.toList and passing and object with length it returns an array with undefined items on it, example

``` javascript
cull.toList({ length:3 });
// returns [undefined, undefined, undefined]
```

i find this kind a weird behavior since 

``` javascript
cull.isList({ length:3 });
// returns true
```

i would expect to maybe have the keys of the object, excluding the length attr, or something on those lines, but since i dont know which direction you want to take i went for the easiest solution adding the object to an array
